### PR TITLE
Fix parseBold function if we have multiple bold strings

### DIFF
--- a/part-09/tests/MarkdownParserTest.php
+++ b/part-09/tests/MarkdownParserTest.php
@@ -27,4 +27,12 @@ class MarkdownParserTest extends PHPUnit_Framework_TestCase
         $r = $m->parseBold($e);
         $this->assertEquals('foo<strong>bar</strong>baz', $r);
     }
+
+    public function testDoubleBoldTextCanBeParsed()
+    {
+        $m = new MarkdownParser;
+        $e = 'foo**bar**baz**boo**';
+        $r = $m->parseBold($e);
+        $this->assertEquals('foo<strong>bar</strong>baz<strong>boo</strong>', $r);
+    }
 }

--- a/part-10/src/Example/MarkdownParser.php
+++ b/part-10/src/Example/MarkdownParser.php
@@ -12,7 +12,7 @@ class MarkdownParser
      */
     public function parseBold($source)
     {
-        $pattern = '/\*\*(.*)\*\*/';
+        $pattern = '/\*\*(.*)\*\*/U';
         $replace = '<strong>$1</strong>';
         return preg_replace($pattern, $replace, $source);
     }

--- a/part-10/tests/MarkdownParserTest.php
+++ b/part-10/tests/MarkdownParserTest.php
@@ -27,4 +27,12 @@ class MarkdownParserTest extends PHPUnit_Framework_TestCase
         $r = $m->parseBold($e);
         $this->assertEquals('foo<strong>bar</strong>baz', $r);
     }
+
+    public function testDoubleBoldTextCanBeParsed()
+    {
+        $m = new MarkdownParser;
+        $e = 'foo**bar**baz**boo**';
+        $r = $m->parseBold($e);
+        $this->assertEquals('foo<strong>bar</strong>baz<strong>boo</strong>', $r);
+    }
 }


### PR DESCRIPTION
By default the preg_replace function is un-greedy. I used the U flag
to make it greedy. I added a new test case to cover this case.

I was not sure, how do you want to handle this case. Should we put
two asserts in one test or write two separated test cases. Or add the
testDoubleBoldTextCanBeParsed test first and fix it in another part.
